### PR TITLE
Library ei is detected by the port compiler

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,10 +7,6 @@
 ]}.
 
 {port_env, [
-    % Drop -lerl_interface
-    {"ERL_LDFLAGS", " -L$ERL_EI_LIBDIR -lei"},
-    {"win32", "ERL_LDFLAGS", " /LIBPATH:$ERL_EI_LIBDIR ei.lib"},
-
     {".*", "FLTO_FLAG", ""},
 
     {"(linux|solaris|freebsd|netbsd|openbsd|dragonfly|darwin|gnu)",

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -54,7 +54,10 @@ case IsRebar2 of
     false ->
         Config2 ++ [
             {plugins, [{pc, "~> 1.0"}]},
-            {artifacts, ["priv/jiffy.so"]},
+            case os:type() of
+                {win32, _} -> {artifacts, ["priv/jiffy.dll"]};
+                {_, _} -> {artifacts, ["priv/jiffy.so"]}
+           end,
             {provider_hooks, [
                 {post, [
                     {compile, {pc, compile}},


### PR DESCRIPTION
After merging https://github.com/apache/couchdb-rebar/pull/10, there is no need of these explicit settings.